### PR TITLE
when calling setHosts() you may want to pass @ through for a Name, so…

### DIFF
--- a/namecheap_api.php
+++ b/namecheap_api.php
@@ -92,7 +92,7 @@ class NamecheapApi {
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_POSTFIELDS, $args);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($args));
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
 		//curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 		//curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);


### PR DESCRIPTION
… you can do the apex record; CURL before PHP 5.6 would think a @ as the first char of a field meant a file was being uploaded, and therefore errored ... passing args through http_build_query(args) stops this behaviour - see also http://stackoverflow.com/questions/648292/escaping-curl-symbol-with-php and https://bugs.php.net/bug.php?id=50060